### PR TITLE
fix: Ensure consistent record ID retrieval after creation

### DIFF
--- a/pkg/tidydns/tidydns.go
+++ b/pkg/tidydns/tidydns.go
@@ -663,7 +663,7 @@ func (c *tidyDNSClient) CreateRecord(ctx context.Context, zoneID int, info Recor
 		return 0, fmt.Errorf(errorTidyDNS, res.Status)
 	}
 
-	recordMergeUrl := fmt.Sprintf("%s/=/record_merged?zone_id=%d", c.baseURL, zoneID)
+	recordMergeUrl := fmt.Sprintf("%s/=/record_merged?type=json&zone_id=%d&showall=1", c.baseURL, zoneID)
 	req, err = http.NewRequestWithContext(
 		ctx,
 		"GET",


### PR DESCRIPTION
Problem:
After creating a new DNS record, the `CreateRecord` function would sometimes fail to find that record's ID because the response on the GET request to `/record_merged` did not always include it in the response on larger zones.

Solution:
Update the GET request to explicitly ask for all records (`showall=1`) and to format the response as JSON (`type=json`). This guarantees that the newly created record is present in the response.